### PR TITLE
Add intial foundry test and setup

### DIFF
--- a/src/UniswapV2ERC20.sol
+++ b/src/UniswapV2ERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import "./interfaces/IUniswapV2ERC20.sol";
 

--- a/src/UniswapV2Factory.sol
+++ b/src/UniswapV2Factory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import "./interfaces/IUniswapV2Factory.sol";
 import "./UniswapV2Pair.sol";

--- a/src/UniswapV2Pair.sol
+++ b/src/UniswapV2Pair.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import {ISuperfluid, ISuperToken, ISuperfluidToken, ISuperApp, ISuperAgreement, SuperAppDefinitions} from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
 import {SuperAppBase} from "@superfluid-finance/ethereum-contracts/contracts/apps/SuperAppBase.sol";

--- a/src/UniswapV2Router.sol
+++ b/src/UniswapV2Router.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 //solhint-disable not-rely-on-time
 //solhint-disable var-name-mixedcase

--- a/src/interfaces/IUniswapV2Router.sol
+++ b/src/interfaces/IUniswapV2Router.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import "./IUniswapV2Router01.sol";
 

--- a/src/interfaces/IUniswapV2Router01.sol
+++ b/src/interfaces/IUniswapV2Router01.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 //solhint-disable func-name-mixedcase
 

--- a/src/interfaces/IWETH.sol
+++ b/src/interfaces/IWETH.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 interface IWETH {
     function deposit() external payable;

--- a/src/libraries/Math.sol
+++ b/src/libraries/Math.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 // a library for performing various math operations
 

--- a/src/libraries/TransferHelper.sol
+++ b/src/libraries/TransferHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 //solhint-disable avoid-low-level-calls
 //solhint-disable reason-string

--- a/src/libraries/UQ112x112.sol
+++ b/src/libraries/UQ112x112.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 // a library for handling binary fixed point numbers (https://en.wikipedia.org/wiki/Q_(number_format))
 

--- a/src/libraries/UniswapV2Library.sol
+++ b/src/libraries/UniswapV2Library.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 //solhint-disable reason-string
 

--- a/src/test/ERC20.sol
+++ b/src/test/ERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import "../UniswapV2ERC20.sol";
 

--- a/src/test/RouterEventEmitter.sol
+++ b/src/test/RouterEventEmitter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 import "../interfaces/IUniswapV2Router01.sol";
 

--- a/src/test/WETH9.sol
+++ b/src/test/WETH9.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.12;
 
 contract WETH9 {
     string public name = "Wrapped Ether";

--- a/test/foundry/UniswapV2Pair.t.sol
+++ b/test/foundry/UniswapV2Pair.t.sol
@@ -1,0 +1,115 @@
+pragma solidity ^0.8.12;
+
+import "forge-std/Test.sol";
+import {UniswapV2Pair} from "../../src/UniswapV2Pair.sol";
+import {UniswapV2Factory} from "../../src/UniswapV2Factory.sol";
+
+import {ISuperfluid} from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
+
+import {SuperfluidFrameworkDeployer, Superfluid, CFAv1Library, IDAv1Library, SuperTokenFactory} from "@superfluid-finance/ethereum-contracts/contracts/utils/SuperfluidFrameworkDeployer.sol";
+import {ConstantFlowAgreementV1} from "@superfluid-finance/ethereum-contracts/contracts/agreements/ConstantFlowAgreementV1.sol";
+import {InstantDistributionAgreementV1} from "@superfluid-finance/ethereum-contracts/contracts/agreements/InstantDistributionAgreementV1.sol";
+import {ERC1820RegistryCompiled} from "@superfluid-finance/ethereum-contracts/contracts/libs/ERC1820RegistryCompiled.sol";
+
+import {TestGovernance} from "@superfluid-finance/ethereum-contracts/contracts/utils/TestGovernance.sol";
+import {TestToken} from "@superfluid-finance/ethereum-contracts/contracts/utils/TestToken.sol";
+import {SuperToken} from "@superfluid-finance/ethereum-contracts/contracts/superfluid/SuperToken.sol";
+
+contract UniswapV2PairTest is Test {
+    UniswapV2Pair public uniswapV2Pair;
+    UniswapV2Factory public uniswapV2Factory;
+    SuperfluidFrameworkDeployer.Framework internal sf;
+    SuperfluidFrameworkDeployer internal deployer;
+
+    TestToken underlyingTokenA;
+    TestToken underlyingTokenB;
+    SuperToken superTokenA;
+    SuperToken superTokenB;
+
+    address internal constant admin = address(0x1);
+    address internal constant alice = address(0x2);
+    address internal constant bob = address(0x3);
+    address internal constant carol = address(0x4);
+    address internal constant dan = address(0x5);
+    address internal constant eve = address(0x6);
+    address internal constant frank = address(0x7);
+    address internal constant grace = address(0x8);
+    address internal constant heidi = address(0x9);
+    address internal constant ivan = address(0x10);
+    address[] internal TEST_ACCOUNTS = [admin, alice, bob, carol, dan, eve, frank, grace, heidi, ivan];
+
+    uint256 internal constant INIT_TOKEN_BALANCE = 10000000;
+    uint256 internal constant INIT_SUPER_TOKEN_BALANCE = 1000000;
+
+    function setUpTokens() public {
+        (underlyingTokenA, superTokenA) = deployer.deployWrapperSuperToken(
+            "Test Token 0",
+            "TT0",
+            18,
+            INIT_TOKEN_BALANCE
+        );
+        (underlyingTokenB, superTokenB) = deployer.deployWrapperSuperToken(
+            "Test Token 0",
+            "TT1",
+            18,
+            INIT_TOKEN_BALANCE
+        );
+
+        for (uint256 i = 0; i < TEST_ACCOUNTS.length; ++i) {
+            underlyingTokenA.mint(TEST_ACCOUNTS[i], INIT_TOKEN_BALANCE);
+
+            vm.startPrank(TEST_ACCOUNTS[i]);
+            underlyingTokenA.approve(address(superTokenA), INIT_TOKEN_BALANCE);
+            superTokenA.upgrade(INIT_SUPER_TOKEN_BALANCE);
+            vm.stopPrank();
+        }
+
+        for (uint256 i = 0; i < TEST_ACCOUNTS.length; ++i) {
+            underlyingTokenB.mint(TEST_ACCOUNTS[i], INIT_TOKEN_BALANCE);
+
+            vm.startPrank(TEST_ACCOUNTS[i]);
+            underlyingTokenB.approve(address(superTokenB), INIT_TOKEN_BALANCE);
+            superTokenB.upgrade(INIT_SUPER_TOKEN_BALANCE);
+            vm.stopPrank();
+        }
+    }
+
+    function setUp() public {
+        vm.etch(ERC1820RegistryCompiled.at, ERC1820RegistryCompiled.bin);
+        deployer = new SuperfluidFrameworkDeployer();
+        deployer.deployTestFramework();
+        sf = deployer.getFramework();
+
+        setUpTokens();
+
+        uniswapV2Factory = new UniswapV2Factory(admin, sf.host);
+        uniswapV2Pair = UniswapV2Pair(uniswapV2Factory.createPair(address(superTokenA), address(superTokenB)));
+    }
+
+    function test_integration_provideLiquidity() public {
+        // Arrange
+        uint256 expectedLiquidity = INIT_SUPER_TOKEN_BALANCE;
+
+        vm.startPrank(admin);
+        superTokenA.transfer(address(uniswapV2Pair), INIT_SUPER_TOKEN_BALANCE);
+        superTokenB.transfer(address(uniswapV2Pair), INIT_SUPER_TOKEN_BALANCE);
+        vm.stopPrank();
+
+        // Act
+        uniswapV2Pair.mint(admin);
+
+        // Assert
+        uint256 totalSupply = uniswapV2Pair.totalSupply();
+        assertEq(totalSupply, expectedLiquidity);
+    }
+
+    function test_getReserves_ReturnsReserves() public {
+        // Arrange & Act
+        (uint112 _reserve0, uint112 _reserve1, uint32 _blockTimestampLast) = uniswapV2Pair.getReserves();
+
+        // Assert
+        assertEq(_reserve0, 0);
+        assertEq(_reserve1, 0);
+        assertEq(_blockTimestampLast, 0);
+    }
+}


### PR DESCRIPTION
- Adds initial foundry test setup and initial test
- Changed solidity versions from `=0.8.12` to `^0.8.12` as latest Superfluid Test contracts had a dependency on version `0.8.19`