### PR TITLE
Make auction upgradeable

### DIFF
--- a/src/AqueductV1Auction.sol
+++ b/src/AqueductV1Auction.sol
@@ -29,8 +29,8 @@ contract AqueductV1Auction is IAqueductV1Auction {
 
     address public immutable override factory;
 
-    constructor() {
-        factory = msg.sender;
+    constructor(address _factory) {
+        factory = _factory;
     }
 
     /**

--- a/src/AqueductV1Factory.sol
+++ b/src/AqueductV1Factory.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.19;
 
 import {IAqueductV1Factory} from "./interfaces/IAqueductV1Factory.sol";
 import {IAqueductV1Auction} from "./interfaces/IAqueductV1Auction.sol";
-import {AqueductV1Auction} from "./AqueductV1Auction.sol";
 import {AqueductV1Pair} from "./AqueductV1Pair.sol";
 import {IAqueductV1Pair} from "./interfaces/IAqueductV1Pair.sol";
 import {ISuperfluid, ISuperToken, SuperAppDefinitions, ISuperApp} from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
@@ -21,15 +20,14 @@ contract AqueductV1Factory is IAqueductV1Factory {
     ISuperfluid immutable host;
 
     // auction
-    IAqueductV1Auction public immutable override auction;
+    IAqueductV1Auction public override auction;
+    address public override auctionSetter;
 
     constructor(address _feeToSetter, ISuperfluid _host) {
         if (address(_host) == address(0)) revert HOST_ZERO_ADDRESS();
         feeToSetter = _feeToSetter;
+        auctionSetter = _feeToSetter; // set auctionSetter the same as fee setter
         host = _host;
-
-        // deploy auction contract
-        auction = new AqueductV1Auction();
     }
 
     function allPairsLength() external view override returns (uint256) {
@@ -65,5 +63,17 @@ contract AqueductV1Factory is IAqueductV1Factory {
         if (msg.sender != feeToSetter) revert FACTORY_FORBIDDEN();
         feeToSetter = _feeToSetter;
         emit SetFeeToSetter(_feeToSetter);
+    }
+
+    function setAuction(address _auction) external override {
+        if (msg.sender != auctionSetter) revert FACTORY_FORBIDDEN();
+        auction = IAqueductV1Auction(_auction);
+        emit SetAuction(_auction);
+    }
+
+    function setAuctionSetter(address _auctionSetter) external override {
+        if (msg.sender != auctionSetter) revert FACTORY_FORBIDDEN();
+        auctionSetter = _auctionSetter;
+        emit SetAuctionSetter(_auctionSetter);
     }
 }

--- a/src/interfaces/IAqueductV1Factory.sol
+++ b/src/interfaces/IAqueductV1Factory.sol
@@ -7,6 +7,8 @@ interface IAqueductV1Factory {
     event PairCreated(address indexed token0, address indexed token1, address pair, uint256);
     event SetFeeTo(address feeTo);
     event SetFeeToSetter(address feeToSetter);
+    event SetAuction(address auction);
+    event SetAuctionSetter(address auctionSetter);
 
     error HOST_ZERO_ADDRESS();
     error FACTORY_IDENTICAL_ADDRESSES();
@@ -17,6 +19,8 @@ interface IAqueductV1Factory {
     function feeTo() external view returns (address);
 
     function feeToSetter() external view returns (address);
+
+    function auctionSetter() external view returns (address);
 
     function getPair(address tokenA, address tokenB) external view returns (address pair);
 
@@ -29,6 +33,10 @@ interface IAqueductV1Factory {
     function setFeeTo(address) external;
 
     function setFeeToSetter(address) external;
+
+    function setAuction(address) external;
+
+    function setAuctionSetter(address) external;
 
     function auction() external view returns (IAqueductV1Auction);
 }

--- a/src/interfaces/IAqueductV1Router01.sol
+++ b/src/interfaces/IAqueductV1Router01.sol
@@ -41,6 +41,22 @@ interface IAqueductV1Router01 {
         bytes32 s
     ) external returns (uint256 amountA, uint256 amountB);
 
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapTokensForExactTokens(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
     function quote(uint256 amountA, uint256 reserveA, uint256 reserveB) external pure returns (uint256 amountB);
 
     function getAmountOut(

--- a/src/test/RouterEventEmitter.sol
+++ b/src/test/RouterEventEmitter.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.12;
+
+import {IAqueductV1Router01} from "../interfaces/IAqueductV1Router01.sol";
+
+contract RouterEventEmitter {
+    event Amounts(uint256[] amounts);
+
+    receive() external payable {}
+
+    function swapExactTokensForTokens(
+        address router,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external {
+        (bool success, bytes memory returnData) = router.delegatecall(
+            abi.encodeWithSelector(
+                IAqueductV1Router01(router).swapExactTokensForTokens.selector,
+                amountIn,
+                amountOutMin,
+                path,
+                to,
+                deadline
+            )
+        );
+        assert(success);
+        emit Amounts(abi.decode(returnData, (uint256[])));
+    }
+
+    function swapTokensForExactTokens(
+        address router,
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external {
+        (bool success, bytes memory returnData) = router.delegatecall(
+            abi.encodeWithSelector(
+                IAqueductV1Router01(router).swapTokensForExactTokens.selector,
+                amountOut,
+                amountInMax,
+                path,
+                to,
+                deadline
+            )
+        );
+        assert(success);
+        emit Amounts(abi.decode(returnData, (uint256[])));
+    }
+}

--- a/src/test/TestFactory.sol
+++ b/src/test/TestFactory.sol
@@ -1,4 +1,3 @@
-
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.19;
 

--- a/src/test/TestFactory.sol
+++ b/src/test/TestFactory.sol
@@ -1,9 +1,9 @@
+
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.19;
 
 import {IAqueductV1Factory} from "../interfaces/IAqueductV1Factory.sol";
 import {IAqueductV1Auction} from "../interfaces/IAqueductV1Auction.sol";
-import {AqueductV1Auction} from "../AqueductV1Auction.sol";
 import {AccumulatorOverride} from "./AccumulatorOverride.sol";
 import {IAqueductV1Pair} from "../interfaces/IAqueductV1Pair.sol";
 import {ISuperfluid, ISuperToken, SuperAppDefinitions, ISuperApp} from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
@@ -13,7 +13,7 @@ import {ISuperfluid, ISuperToken, SuperAppDefinitions, ISuperApp} from "@superfl
     This contract is a copy of AqueductV1Factory, but deploys AccumulatorOverride instead of AqueductV1Pair
 
     AccumulatorOverride is used to set accumulators to arbitrary values (to test overflow)
-    
+
 */
 
 contract TestFactory is IAqueductV1Factory {
@@ -29,15 +29,14 @@ contract TestFactory is IAqueductV1Factory {
     ISuperfluid immutable host;
 
     // auction
-    IAqueductV1Auction public immutable override auction;
+    IAqueductV1Auction public override auction;
+    address public override auctionSetter;
 
     constructor(address _feeToSetter, ISuperfluid _host) {
         if (address(_host) == address(0)) revert HOST_ZERO_ADDRESS();
         feeToSetter = _feeToSetter;
+        auctionSetter = _feeToSetter; // set auctionSetter the same as fee setter
         host = _host;
-
-        // deploy auction contract
-        auction = new AqueductV1Auction();
     }
 
     function allPairsLength() external view override returns (uint256) {
@@ -73,5 +72,17 @@ contract TestFactory is IAqueductV1Factory {
         if (msg.sender != feeToSetter) revert FACTORY_FORBIDDEN();
         feeToSetter = _feeToSetter;
         emit SetFeeToSetter(_feeToSetter);
+    }
+
+    function setAuction(address _auction) external override {
+        if (msg.sender != auctionSetter) revert FACTORY_FORBIDDEN();
+        auction = IAqueductV1Auction(_auction);
+        emit SetAuction(_auction);
+    }
+
+    function setAuctionSetter(address _auctionSetter) external override {
+        if (msg.sender != auctionSetter) revert FACTORY_FORBIDDEN();
+        auctionSetter = _auctionSetter;
+        emit SetAuctionSetter(_auctionSetter);
     }
 }

--- a/test/hardhat/AqueductV1Auction.spec.ts
+++ b/test/hardhat/AqueductV1Auction.spec.ts
@@ -110,6 +110,11 @@ describe("AqueductV1Auction", () => {
         const token0 = tokenA.address === token0Address ? tokenA : tokenB;
         const token1 = tokenA.address === token0Address ? tokenB : tokenA;
 
+        // deploy auction and assign to factory
+        const auctionFactory = await ethers.getContractFactory("AqueductV1Auction");
+        const deployedAuction = await auctionFactory.deploy(factory.address);
+        await factory.setAuction(deployedAuction.address);
+
         // approve max amount for every user
         await token0
             .approve({
@@ -124,7 +129,7 @@ describe("AqueductV1Auction", () => {
             })
             .exec(wallet);
 
-        const auction = (await ethers.getContractFactory("AqueductV1Auction")).attach(await factory.auction());
+        const auction = (auctionFactory).attach(await factory.auction());
 
         return { pair, token0, token1, wallet, other, factory, auction, attacker };
     }

--- a/test/hardhat/AqueductV1Auction.spec.ts
+++ b/test/hardhat/AqueductV1Auction.spec.ts
@@ -129,7 +129,7 @@ describe("AqueductV1Auction", () => {
             })
             .exec(wallet);
 
-        const auction = (auctionFactory).attach(await factory.auction());
+        const auction = auctionFactory.attach(await factory.auction());
 
         return { pair, token0, token1, wallet, other, factory, auction, attacker };
     }

--- a/test/hardhat/AqueductV1Factory.spec.ts
+++ b/test/hardhat/AqueductV1Factory.spec.ts
@@ -125,7 +125,9 @@ describe("AqueductV1Factory", () => {
             factory,
             "FACTORY_FORBIDDEN"
         );
-        await expect(factory.setAuctionSetter(other.address)).to.emit(factory, "SetAuctionSetter").withArgs(other.address);
+        await expect(factory.setAuctionSetter(other.address))
+            .to.emit(factory, "SetAuctionSetter")
+            .withArgs(other.address);
         expect(await factory.auctionSetter()).to.eq(other.address);
         await expect(factory.setAuctionSetter(wallet.address)).to.be.revertedWithCustomError(
             factory,

--- a/test/hardhat/AqueductV1Factory.spec.ts
+++ b/test/hardhat/AqueductV1Factory.spec.ts
@@ -108,4 +108,28 @@ describe("AqueductV1Factory", () => {
             "FACTORY_FORBIDDEN"
         );
     });
+
+    it("setAuction", async () => {
+        const { factory, wallet, other } = await loadFixture(fixture);
+        await expect(factory.connect(other).setAuction(other.address)).to.be.revertedWithCustomError(
+            factory,
+            "FACTORY_FORBIDDEN"
+        );
+        await expect(factory.setAuction(wallet.address)).to.emit(factory, "SetAuction").withArgs(wallet.address);
+        expect(await factory.auction()).to.eq(wallet.address);
+    });
+
+    it("setAuctionSetter", async () => {
+        const { factory, wallet, other } = await loadFixture(fixture);
+        await expect(factory.connect(other).setAuctionSetter(other.address)).to.be.revertedWithCustomError(
+            factory,
+            "FACTORY_FORBIDDEN"
+        );
+        await expect(factory.setAuctionSetter(other.address)).to.emit(factory, "SetAuctionSetter").withArgs(other.address);
+        expect(await factory.auctionSetter()).to.eq(other.address);
+        await expect(factory.setAuctionSetter(wallet.address)).to.be.revertedWithCustomError(
+            factory,
+            "FACTORY_FORBIDDEN"
+        );
+    });
 });

--- a/test/hardhat/AqueductV1Pair.spec.ts
+++ b/test/hardhat/AqueductV1Pair.spec.ts
@@ -376,8 +376,8 @@ describe("AqueductV1Pair", () => {
             params: [auctionAddress],
         });
         await expect(pair.connect(mockAuctionSigner).swap(0, expectedOutputAmount, wallet.address))
-            //.to.emit(token1, "Transfer")
-            //.withArgs(pair.address, wallet.address, expectedOutputAmount)
+            .to.emit(new ethers.Contract(token1.address, erc20Abi, owner), "Transfer")
+            .withArgs(pair.address, wallet.address, expectedOutputAmount)
             .to.emit(pair, "Sync")
             .withArgs(token0Amount.add(swapAmount), token1Amount.sub(expectedOutputAmount))
             .to.emit(pair, "Swap")
@@ -435,8 +435,8 @@ describe("AqueductV1Pair", () => {
             params: [auctionAddress],
         });
         await expect(pair.connect(mockAuctionSigner).swap(expectedOutputAmount, 0, wallet.address))
-            //.to.emit(token0, "Transfer")
-            //.withArgs(pair.address, wallet.address, expectedOutputAmount)
+            .to.emit(new ethers.Contract(token0.address, erc20Abi, owner), "Transfer")
+            .withArgs(pair.address, wallet.address, expectedOutputAmount)
             .to.emit(pair, "Sync")
             .withArgs(token0Amount.sub(expectedOutputAmount), token1Amount.add(swapAmount))
             .to.emit(pair, "Swap")

--- a/test/hardhat/AqueductV1Pair.spec.ts
+++ b/test/hardhat/AqueductV1Pair.spec.ts
@@ -124,6 +124,11 @@ describe("AqueductV1Pair", () => {
         const token0 = tokenA.address === token0Address ? tokenA : tokenB;
         const token1 = tokenA.address === token0Address ? tokenB : tokenA;
 
+        // deploy auction and assign to factory
+        const auctionFactory = await ethers.getContractFactory("AqueductV1Auction");
+        const deployedAuction = await auctionFactory.deploy(factory.address);
+        await factory.setAuction(deployedAuction.address);
+
         // approve max amount for every user
         await token0
             .approve({


### PR DESCRIPTION
The 'auction' essentially just controls the swap() function in all pools (which handles discrete swaps, and is expected to be used primarily for arbitrage). 

We'd like to have the temporary ability to modify the auction interface if needed. This includes the following changes
- inside pair.swap(), it will check that it is being called by factory.auction(), so to 'upgrade' the auction, we just need to change this address
- need to add a new address that is allowed to set the auction address, similar to the feeToSetter address
- we also need a setter for that address, similar to setFeeToSetter, that allows us to change the address, and eventually self-revoke these permissions by setting it to the zero address
- revert the state of the router contract to support token swaps, we can then use the router in place of the auction to enable atomic arbitrage